### PR TITLE
Update semantics around how pipeline defaults are set

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -1,22 +1,22 @@
-##' @title Apply THF defaults
-##' @param metadata A 'base' setup, e.g. from \code{\link{ons_datasets_setup}}
+##' @title Create the THF defaults
 ##' @param download_root Root of directory hierarchy.
 ##' @return an augmented metadata
 ##' @author Neale Swinnerton <neale@mastodonc.com>
 ##' @export
 ##' @import here
-thf_pipeline_defaults <- function(metadata, download_root="") {
+thf_pipeline_defaults <- function(download_root="") {
     basedir <- "{{download_root}}/data"
     filepath <- "{{datasource}}/{{dataset}}/{{edition}}/{{dataset}}-v{{version}}.{{format}}"
 
-    metadata$thf$download_filename_template = sprintf("%s/raw/%s",
+    metadata <- list()
+    metadata$download_filename_template = sprintf("%s/raw/%s",
                                                 basedir,
                                                 filepath)
-    metadata$thf$clean_filename_template = sprintf("%s/clean/%s",
+    metadata$clean_filename_template = sprintf("%s/clean/%s",
                                              basedir,
                                              filepath)
     if (missing(download_root)) {
-        metadata$thf$download_root = here::here() # TODO here supposedly for
+        metadata$download_root = here::here() # TODO here supposedly for
                                             # interactive use?
     }
     metadata

--- a/R/ons.R
+++ b/R/ons.R
@@ -63,15 +63,22 @@ ons_api_call <- function(url) {
 ##' @export
 ##' @import jsonlite
 ##' @import dplyr
-ons_datasets_setup <- function() {
+##' @examples
+##' \dontrun{
+##' ons_datasets_setup(thf_pipeline_defaults()) # rooted in current project
+##' }
+##' \dontrun{
+##' ons_datasets_setup(thf_pipeline_defaults(download_root="/path/to/download/root/"))
+##' }
+ons_datasets_setup <- function(defaults) {
     results <- ons_api_call(api_base_url)
-    results$thf <- dplyr::tibble(src_url = api_base_url)
+    results$thf <- defaults
+    results$thf$src_url <-  api_base_url
 
     results
 }
 
 ##' @title Available Datasets
-##' @param metadata data describing the datasets from \code{ons_datasets_setup()}
 ##' @return list of available datasets
 ##' @author Neale Swinnerton <neale@mastodonc.com>
 ##' @export
@@ -80,7 +87,7 @@ ons_datasets_setup <- function() {
 #' \dontrun{
 #' ons_available_datasets()
 #' }
-ons_available_datasets <- function(metadata) {
+ons_available_datasets <- function() {
     ons_api_call(api_base_url)$items %>% dplyr::select(id)
 }
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ remotes::install_github("HFAnalyticsLab/monstR", build_vignettes = TRUE )
 
 ## Design Principles
 
-The THF Open Data Pipeline is designed to work well with tidyverse and in particular within pipelines created by the `%>%` pipe operator. With this in mind, most functions take a dataframe (or equivalent, such as a `dplyr::tibble`) in the first argument and return a dataframe which has been augmented in some way.
+The THF Open Data Pipeline is designed to work well with tidyverse and in particular within pipelines created by the `%>%` pipe operator. With this in mind, most functions take a data structure in the first argument and return a data structure which has been augmented in some way. Typically this is metadata about the actual data, although once the data has been cleaned it can be accessed using `thf_data(metadata)` to get at a tidyverse tibble of the data.
 
 
 ## Authors

--- a/man/ons_api_call.Rd
+++ b/man/ons_api_call.Rd
@@ -10,7 +10,7 @@ ons_api_call(url)
 \item{url}{url to call @seeAlso \code{\link{[api_base_url]}}}
 }
 \value{
-a dataframe contained the API call results
+a list contained the API call results
 }
 \description{
 Make request to given url, which is assumed to be the ONS api.

--- a/man/ons_available_datasets.Rd
+++ b/man/ons_available_datasets.Rd
@@ -4,10 +4,7 @@
 \alias{ons_available_datasets}
 \title{Available Datasets}
 \usage{
-ons_available_datasets(df)
-}
-\arguments{
-\item{df}{dataframe describing the datasets from \code{ons_datasets_setup()}}
+ons_available_datasets()
 }
 \value{
 list of available datasets

--- a/man/ons_dataset_by_id.Rd
+++ b/man/ons_dataset_by_id.Rd
@@ -4,10 +4,10 @@
 \alias{ons_dataset_by_id}
 \title{Dataset By Id}
 \usage{
-ons_dataset_by_id(df, id, edition, version)
+ons_dataset_by_id(metadata, id, edition, version)
 }
 \arguments{
-\item{df}{dataframe describing the dataset}
+\item{metadata}{data describing the dataset}
 
 \item{id}{the identifier of the dataset. Valid values from \code{ons_available_datasets()}}
 

--- a/man/ons_datasets_setup.Rd
+++ b/man/ons_datasets_setup.Rd
@@ -4,10 +4,10 @@
 \alias{ons_datasets_setup}
 \title{Datasets Setup}
 \usage{
-ons_datasets_setup()
+ons_datasets_setup(defaults)
 }
 \value{
-a dataframe describing available datasets
+a list describing available datasets
 }
 \description{
 Retrieves a dataframe describing the datasets available from ONS via the API.
@@ -15,6 +15,14 @@ Retrieves a dataframe describing the datasets available from ONS via the API.
 \details{
 This returns a dataframe containing details that can be passed to
 other fns in this package for further processing
+}
+\examples{
+\dontrun{
+ons_datasets_setup(thf_pipeline_defaults()) # rooted in current project
+}
+\dontrun{
+ons_datasets_setup(thf_pipeline_defaults(download_root="/path/to/download/root/"))
+}
 }
 \author{
 Neale Swinnerton \href{mailto:neale@mastodonc.com}{neale@mastodonc.com}

--- a/man/ons_download.Rd
+++ b/man/ons_download.Rd
@@ -4,10 +4,10 @@
 \alias{ons_download}
 \title{Download}
 \usage{
-ons_download(df, format = "csv")
+ons_download(metadata, format = "csv")
 }
 \arguments{
-\item{df}{dataframe describing the download}
+\item{metadata}{data describing the download}
 
 \item{format}{a valid format for the download}
 }

--- a/man/thf_clean.Rd
+++ b/man/thf_clean.Rd
@@ -4,13 +4,13 @@
 \alias{thf_clean}
 \title{Clean the data according to THF rules.}
 \usage{
-thf_clean(df)
+thf_clean(metadata)
 }
 \arguments{
-\item{df}{dataframe describing the downloaded file.}
+\item{metadata}{description the downloaded file.}
 }
 \value{
-a cleaned dataframe
+description of the cleaned data
 }
 \description{
 Clean the data according to THF rules.

--- a/man/thf_data.Rd
+++ b/man/thf_data.Rd
@@ -4,10 +4,10 @@
 \alias{thf_data}
 \title{Get the Data}
 \usage{
-thf_data(df)
+thf_data(metadata)
 }
 \arguments{
-\item{df}{describing the downloaded data}
+\item{metadata}{description of the downloaded data}
 }
 \value{
 a \code{\link[tibble]{dplyr::tibble}} of the data from the

--- a/man/thf_pipeline_defaults.Rd
+++ b/man/thf_pipeline_defaults.Rd
@@ -2,20 +2,18 @@
 % Please edit documentation in R/clean.R
 \name{thf_pipeline_defaults}
 \alias{thf_pipeline_defaults}
-\title{Apply THF defaults}
+\title{Create the THF defaults}
 \usage{
-thf_pipeline_defaults(df, download_root = "")
+thf_pipeline_defaults(download_root = "")
 }
 \arguments{
-\item{df}{A 'base' setup, e.g. from \code{\link{ons_datasets_setup}}}
-
 \item{download_root}{Root of directory hierarchy.}
 }
 \value{
-an augmented dataframe
+an augmented metadata
 }
 \description{
-Apply THF defaults
+Create the THF defaults
 }
 \author{
 Neale Swinnerton \href{mailto:neale@mastodonc.com}{neale@mastodonc.com}

--- a/man/thf_read_file.Rd
+++ b/man/thf_read_file.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/clean.R
 \name{thf_read_file}
 \alias{thf_read_file}
-\title{Read the file described by the df}
+\title{Read the file described by the metadata}
 \usage{
-thf_read_file(df)
+thf_read_file(metadata)
 }
 \arguments{
-\item{df}{dataframe describing the downloaded file.}
+\item{metadata}{description of the downloaded file.}
 }
 \value{
-a df incorporating the data. The actually data can then be
+a metadata incorporating the data. The actually data can then be
 extracted with \code{\link{thf_data}}
 }
 \description{
-Read the file described by the df
+Read the file described by the metadata
 }
 \author{
 Neale Swinnerton \href{mailto:neale@mastodonc.com}{neale@mastodonc.com}

--- a/man/thf_write_clean.Rd
+++ b/man/thf_write_clean.Rd
@@ -4,10 +4,10 @@
 \alias{thf_write_clean}
 \title{Writes the data to the 'clean' area}
 \usage{
-thf_write_clean(df, format = "csv", create_directory = TRUE)
+thf_write_clean(metadata, format = "csv", create_directory = TRUE)
 }
 \arguments{
-\item{df}{dataframe describing the data.}
+\item{metadata}{description of the data.}
 
 \item{format}{any known format or "all" to save a copy as all
 known formats}

--- a/vignettes/pipeline.Rmd
+++ b/vignettes/pipeline.Rmd
@@ -19,8 +19,7 @@ library(magrittr)
 
   # ons_* fns relate only to ONS datasource
   # thf_* fns are general purpose for all datasources
-> ons_datasets_setup() %>%
-	thf_pipeline_defaults() %>% # Uses the thf 'standards' for location and format
+> ons_datasets_setup(thf_pipeline_defaults()) %>% # Uses the thf 'standards' for location and format
 	ons_dataset_by_id("weekly-deaths-local-authority") %>%
 	ons_download(format="csv") %>%
 	thf_read_file() %>%  
@@ -78,7 +77,7 @@ library(magrittr)
 
 <!-- Important that eval = FALSE here, otherwise building the vignette downloads data from the ONS API, which is not desirable. -->
 ```{r , eval = FALSE, include = TRUE}
-ons_datasets_setup() %>%
+ons_datasets_setup(thf_pipeline_defaults()) %>%
 	ons_dataset_by_id("weekly-deaths-local-authority") %>%
 	ons_download(format="csv")
 
@@ -89,7 +88,7 @@ ons_datasets_setup() %>%
 ### Similarly it can be downloaded as an xls
 <!-- Important that eval = FALSE here, otherwise building the vignette downloads data from the ONS API, which is not desirable. -->
 ```{r , eval = FALSE, include = TRUE}
-ons_datasets_setup() %>%
+ons_datasets_setup(thf_pipeline_defaults()) %>%
 	ons_dataset_by_id("weekly-deaths-local-authority") %>%
 	ons_download(format="xls")
 ```
@@ -98,7 +97,7 @@ ons_datasets_setup() %>%
 ### Specific versions can be selected.
 <!-- Important that eval = FALSE here, otherwise building the vignette downloads data from the ONS API, which is not desirable. -->
 ```{r , eval = FALSE, include = TRUE}
-datasets <- ons_datasets_setup()
+datasets <- ons_datasets_setup(thf_pipeline_defaults())
 ## get the metadata about v4 of the time-series edition of weekly-deaths-local-authority dataset.
 wdla4_meta <- datasets %>% ons_dataset_by_id("weekly-deaths-local-authority", edition="time-series", version=4)
 


### PR DESCRIPTION
Pass defaults at start to avoid 'not found' type errors later in the
pipeline.

We want users to explicitly choose download directories and other
defaults so we don't have a 'silent' default.

Note: This picks up some documentation changes from #13 where the documentation hadn't been commited. But the code changes are just for #9 