### PR TITLE
Make creation of LATEST symlink optional (default to NOT creating)

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -15,6 +15,7 @@ monstr_pipeline_defaults <- function(download_root="") {
     metadata$clean_filename_template = sprintf("%s/clean/%s",
                                              basedir,
                                              filepath)
+    metadata$create_latest_symlink <- FALSE
     if (missing(download_root)) {
         metadata$download_root = here::here() # TODO here supposedly for
                                             # interactive use?

--- a/R/ons.R
+++ b/R/ons.R
@@ -252,7 +252,8 @@ try (if(!(format %in% c('csv', 'xls'))) stop('Format not allowed'))
         logger::log_info(sprintf("File created at %s ", destfile))
     }
 
-    if (metadata$monstr$is_latest) {
+    if (metadata$monstr$create_latest_symlink &&
+        metadata$monstr$is_latest) {
 
         version <- metadata$monstr$version
         metadata$monstr$version <- "LATEST"


### PR DESCRIPTION
On windows, the create symbolic link permission is not widely
available to unprivileged user. We should default to NOT requiring
it. If a user has that permission, they can update the defaults
supplied to the setup function (`create_latest_symlink <- TRUE`)